### PR TITLE
An attempt at documentation leaning on typescript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,71 @@
 # Flat File Creator
 
-## It allows to generate a flat positional file, using an object that defines its structure
+This library allows to generate a flat positional file, using an array that defines it's structure
 
-`getAsyncFlatFileCreator(maps: [MapDefinition], options: FlatFileOptions)` :
-FlatFileCreator
+### Generate your asynchronous file creator:
+The method `getAsyncFlatFileCreator` returns a function configured through the two required parameters, maps and options. The maps array parameter will contain the definition of the line structure of the text file, options allows you to configure some general options of the file that will be created.
 
-- maps: positional flat file definition
-- options: additional options (optional)
+`getAsyncFlatFileCreator(maps: [MapDefinitioObject], options: FlatFileOptions)`: FlatFileCreator
 
-`FlatFileCreator(data: [any], path: String)`
+#### `"maps": [MapDefinitioObject]` - positional row definition param 
+The array is made up of objects defines the composition of each line.
 
-- data: dataset to flat
-- path: path to store file
+The necessary attributes of the objects contained in the array are:
 
-## Project is currently in progress
+- `name: string` this attribute is the reference to the name of the attribute that must be present in the dataset that will be passed to the generated function to process the value and position it in the desired point;
+- `size: numeric` is the total dimension that the field will have in the generated file;
+- `type: string ` is the reference to the data type related to the field and can have the following values: 
+
+  - `string`
+  - `float`
+  - `integer`
+  - `date`
+  
+  the other attributes that are needed depend on the type chosen
+  
+#### `options: object` additional options (optional)
+Option object is optional if it not will provided file will be generated with default option.
+
+- rowEnd: defines the terminator character of each line; `default: ''`
+- encoding: it's relative to the file encoding provided by the fs node module;`default: 'utf8'`
+- mode: it's relative to the file save mode provided by the fs node module;`default: 0o666`
+- flag: it's relative to the file save flag provided by the fs node module;`default: 'a'`
+  
+#### Data types
+specific attribute required by chosen data type
+
+#### `string`
+
+-  `preserveEmptySpace: boolean`: `default: true`
+-  `paddingPosition: 'start' | 'end`: `default: 'end'`
+-  `paddingSymbol: string`: `default: ' '`
+
+#### `integer`
+
+-  `paddingPosition: 'start' | 'end`: `default: 'start'`
+-  `paddingSymbol: string`: `default: ' '`
+
+#### `float`
+
+-  `precision:numeric`: `default: 0`
+-  `dotNotation: boolean`: dot notation use a dot to divide decimal part, instead to use zero to fill to a fixed position `default: false`
+-  `paddingPosition: 'start' | 'end`: `default: 'start'`
+-  `paddingSymbol: string`: `default: ' '`
+
+#### `date`
+
+-  `paddingPosition: 'start' | 'end`: `default: 'end'`
+-  `paddingSymbol: string`: `default: ' '`
+-  `format: {utc:Boolean,dateFormat: string }`: 
+    dateFormnat use moment.js format style, if dateFormat is not provided will be used ISO format; `default: {utc: false}`
+
+
+### Use flat file creator:
+Use the generated function to create the flat file providing the dataset array and the destination file path.
+
+`FlatFileCreator(data: [any], path: string): Promise`
+
+- data: dataset that contains data to put into the flat file
+- path: path and name of file that will be generated
+
+

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ This library allows to generate a flat positional file, using an array that defi
 > ```
 >
 
+## In-Depth Explanation
+
 ### Generate your asynchronous file creator:
 The method `getAsyncFlatFileCreator` returns a function configured through the two required
 parameters, `maps` and `options`.

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -42,7 +42,7 @@ export type FieldSpec = (
 ) & { type?: 'string' | 'integer' | 'float' | 'date' }
 
 // String field parameters
-type StringFieldSpec = CommonSpec & {
+export type StringFieldSpec = CommonSpec & {
   type: 'string'
 
   /**
@@ -58,12 +58,12 @@ type StringFieldSpec = CommonSpec & {
 }
 
 // Integer fields - there are no additional parameters
-type IntegerFieldSpec = CommonSpec & {
+export type IntegerFieldSpec = CommonSpec & {
   type: 'integer'
 }
 
 // Float field parameters
-type FloatFieldSpec = CommonSpec & {
+export type FloatFieldSpec = CommonSpec & {
   type: 'float'
 
   /**
@@ -82,7 +82,7 @@ type FloatFieldSpec = CommonSpec & {
 }
 
 // Date field parameters
-type DateFieldSpec = CommonSpec & {
+export type DateFieldSpec = CommonSpec & {
   type: 'date'
   format?: {
     /**

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -3,9 +3,28 @@ import { isNumeric } from './utils'
 
 // Options to be used to configure the file creator instance as a whole
 export interface GlobalOptions {
+  /**
+   * Defines the terminator character of each line
+   * @default ''
+   */
   rowEnd: string
+
+  /**
+   * It's relative to the file encoding provided by the fs node module
+   * @default 'utf8'
+   */
   encoding?: BufferEncoding
+
+  /**
+   * It's relative to the file save mode provided by the fs node module
+   * @default 0o666
+   */
   mode?: number
+
+  /**
+   * It's relative to the file save flag provided by the fs node module
+   * @default 'a'
+   */
   flag?: string
 }
 
@@ -13,7 +32,7 @@ export interface GlobalOptions {
 export type FieldValue = string | number | boolean | Date
 export type RowData = { [fieldName: string]: FieldValue }
 
-// Specifications for various types of fields.
+// FieldSpec is a discriminated union of all possible field spec types
 // Here, we make 'type' optional since field specs default to string-type
 export type FieldSpec = (
   | StringFieldSpec
@@ -22,26 +41,93 @@ export type FieldSpec = (
   | DateFieldSpec
 ) & { type?: 'string' | 'integer' | 'float' | 'date' }
 
-export type StringFieldSpec = CommonSpec & { type: 'string' } & {
-  preserveEmptySpace: boolean
-  straight: boolean // (should be "strict" - determines whether or not error is thrown if incoming data is numeric, rather than string)
-}
-export type IntegerFieldSpec = CommonSpec & { type: 'integer' }
-export type FloatFieldSpec = CommonSpec & { type: 'float' } & {
-  precision?: number
-  dotNotation?: boolean
-}
-export type DateFieldSpec = CommonSpec & { type: 'date' } & {
-  format?: {
-    utc?: boolean
-    dateFormat?: string
+// String field parameters
+type StringFieldSpec =
+  CommonSpec &
+  {
+    type: 'string'
+
+    /**
+     * Whether or not to trim whitespace from the value
+     * @default true
+     */
+    preserveEmptySpace: boolean
+
+    /**
+     * If true, any values that are not string types will throw an exception
+     */
+    straight: boolean
   }
-}
+
+// Integer fields - there are no additional parameters
+type IntegerFieldSpec =
+  CommonSpec & {
+    type: 'integer'
+  }
+
+// Float field parameters
+type FloatFieldSpec =
+  CommonSpec & {
+    type: 'float'
+
+    /**
+     * When `dotNotation` is true, represents the number of digits to the right of the decimal
+     * point. When `dotNotation` is false, defines the multiplication factor used to obtain the
+     * integer value of the number (see `dotNotation` below).
+     */
+    precision?: number
+
+    /**
+     * When false, number is represented as an integer by multiplying by 10^[precision]. For
+     * example, if precision is 4, then the value `156.34235568183` would be represented as
+     * the integer `1563424`.
+     */
+    dotNotation?: boolean
+  }
+
+// Date field parameters
+type DateFieldSpec =
+  CommonSpec & {
+    type: 'date'
+    format?: {
+      /**
+       * Use UTC for times
+       * @default false
+       */
+      utc?: boolean
+
+      /**
+       * Specify an arbitrary date format (see [`moment`](https://momentjs.com/docs/#/displaying/))
+       * @default ISO format
+       */
+      dateFormat?: string
+    }
+  }
+
 
 declare type CommonSpec = {
+  /**
+   * This attribute is the reference to the name of the attribute that must be present in the
+   * dataset that will be passed to the generated function to process the value and position it
+   * in the desired point in the file
+   */
   name: string
+
+  /**
+   * The total dimension that the field will have in the generated file;
+   */
   size: number
+
+  /**
+   * Whether padding for this field should be at the beginning or the end
+   * @default 'end' for string and date fields, 'start' for number fields
+   */
   paddingPosition?: 'start' | 'end'
+
+  /**
+   * What character should be used as padding
+   * @default ' ' (space)
+   */
   paddingSymbol?: string
 }
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -42,68 +42,62 @@ export type FieldSpec = (
 ) & { type?: 'string' | 'integer' | 'float' | 'date' }
 
 // String field parameters
-type StringFieldSpec =
-  CommonSpec &
-  {
-    type: 'string'
+type StringFieldSpec = CommonSpec & {
+  type: 'string'
 
-    /**
-     * Whether or not to trim whitespace from the value
-     * @default true
-     */
-    preserveEmptySpace: boolean
+  /**
+   * Whether or not to trim whitespace from the value
+   * @default true
+   */
+  preserveEmptySpace: boolean
 
-    /**
-     * If true, any values that are not string types will throw an exception
-     */
-    straight: boolean
-  }
+  /**
+   * If true, any values that are not string types will throw an exception
+   */
+  straight: boolean
+}
 
 // Integer fields - there are no additional parameters
-type IntegerFieldSpec =
-  CommonSpec & {
-    type: 'integer'
-  }
+type IntegerFieldSpec = CommonSpec & {
+  type: 'integer'
+}
 
 // Float field parameters
-type FloatFieldSpec =
-  CommonSpec & {
-    type: 'float'
+type FloatFieldSpec = CommonSpec & {
+  type: 'float'
 
-    /**
-     * When `dotNotation` is true, represents the number of digits to the right of the decimal
-     * point. When `dotNotation` is false, defines the multiplication factor used to obtain the
-     * integer value of the number (see `dotNotation` below).
-     */
-    precision?: number
+  /**
+   * When `dotNotation` is true, represents the number of digits to the right of the decimal
+   * point. When `dotNotation` is false, defines the multiplication factor used to obtain the
+   * integer value of the number (see `dotNotation` below).
+   */
+  precision?: number
 
-    /**
-     * When false, number is represented as an integer by multiplying by 10^[precision]. For
-     * example, if precision is 4, then the value `156.34235568183` would be represented as
-     * the integer `1563424`.
-     */
-    dotNotation?: boolean
-  }
+  /**
+   * When false, number is represented as an integer by multiplying by 10^[precision]. For
+   * example, if precision is 4, then the value `156.34235568183` would be represented as
+   * the integer `1563424`.
+   */
+  dotNotation?: boolean
+}
 
 // Date field parameters
-type DateFieldSpec =
-  CommonSpec & {
-    type: 'date'
-    format?: {
-      /**
-       * Use UTC for times
-       * @default false
-       */
-      utc?: boolean
+type DateFieldSpec = CommonSpec & {
+  type: 'date'
+  format?: {
+    /**
+     * Use UTC for times
+     * @default false
+     */
+    utc?: boolean
 
-      /**
-       * Specify an arbitrary date format (see [`moment`](https://momentjs.com/docs/#/displaying/))
-       * @default ISO format
-       */
-      dateFormat?: string
-    }
+    /**
+     * Specify an arbitrary date format (see [`moment`](https://momentjs.com/docs/#/displaying/))
+     * @default ISO format
+     */
+    dateFormat?: string
   }
-
+}
 
 declare type CommonSpec = {
   /**


### PR DESCRIPTION
@cimasim89 rather than trying to comment on your PR, I figured it may be easier to just edit your docs and see what you think.

Here, I've added documentation directly to the `src/Types.ts` file, then copied that over into the readme for easy consumption. Additionally, I've add the TL;DR we talked about.

[Here](https://github.com/cimasim89/flat-file-creator/blob/feature/6b-add-documentation/README.md)'s a link to the formatted file for convenience.

Lemme know what you think.